### PR TITLE
Fixes "not well formed" error

### DIFF
--- a/assets/js/magister.js
+++ b/assets/js/magister.js
@@ -1,4 +1,11 @@
 $(function () {
+	$.ajaxSetup({beforeSend: function(xhr){
+		if (xhr.overrideMimeType)
+		{
+			xhr.overrideMimeType("application/json");
+		}
+	}
+	}); //Changes JSON MIME-type to text/JSON instead of text/plain
 	
 	var dim = false;
 


### PR DESCRIPTION
The JSON files are being read as text/plain on firefox.

(I have no idea what those error messages are on chrome)